### PR TITLE
Fixed an issue with the extension not working with tabs-indented files, slightly improved style

### DIFF
--- a/main.css
+++ b/main.css
@@ -1,0 +1,3 @@
+.cm-tab {
+  display: inline;
+}

--- a/main.js
+++ b/main.js
@@ -1,6 +1,9 @@
 define(function (require, exports, module) {
   "use strict";
 
+  var ExtensionUtils = brackets.getModule("utils/ExtensionUtils");
+  ExtensionUtils.loadStyleSheet(module, "main.css");
+
   /**
    * Indent softwrapped lines
    * @param editor Instance of Editor
@@ -10,21 +13,19 @@ define(function (require, exports, module) {
     if (!editor) return;
     var changedSomething = false;
     editor._codeMirror.on("renderLine", function (cm, line, elt) {
-      var firstNonSpace = line.text.search(/[^\s\t]/);
+      var firstNonSpace = line.text.search(/\S/);
       var tabsCount = line.text.substr(0, firstNonSpace).replace(/[^\t]/g, "").length;
-      var off = firstNonSpace * cm.defaultCharWidth() + tabsCount * cm.getOption("tabSize");
-      if (tabsCount === 0) { // only if no tabs!
-        var compStyle = window.getComputedStyle(elt, null),
-            textIndent = "-" + off + "px",
-            paddingLeft = off + "px";
-        if (textIndent != compStyle["text-indent"]) {
-          elt.style.textIndent = textIndent;
-          changedSomething = true;
-        }
-        if (paddingLeft != compStyle["padding-left"]) {
-          elt.style.paddingLeft = paddingLeft;
-          changedSomething = true;
-        }
+      var off = ((firstNonSpace - tabsCount) + (tabsCount * cm.getOption("tabSize"))) * cm.defaultCharWidth();
+      var compStyle = window.getComputedStyle(elt, null),
+          textIndent = "-" + off + "px",
+          paddingLeft = off + "px";
+      if (textIndent != compStyle["text-indent"]) {
+        elt.style.textIndent = textIndent;
+        changedSomething = true;
+      }
+      if (paddingLeft != compStyle["padding-left"]) {
+        elt.style.paddingLeft = paddingLeft;
+        changedSomething = true;
       }
     });
     if (changedSomething || forceRefresh) {
@@ -32,12 +33,12 @@ define(function (require, exports, module) {
     }
   }
 
-  var AppInit = brackets.getModule('utils/AppInit'),
+  var AppInit = brackets.getModule("utils/AppInit"),
       EditorManager = brackets.getModule("editor/EditorManager");
 
   AppInit.appReady(function () {
     handleEditor(EditorManager.getCurrentFullEditor(), true); // Force refresh when started
-    $(EditorManager).on('activeEditorChange', function (event, focusedEditor, lostEditor) {
+    $(EditorManager).on("activeEditorChange", function (event, focusedEditor, lostEditor) {
       handleEditor(focusedEditor, false);
     });
   });


### PR DESCRIPTION
I fixed the issue you had with the extension not working with tabs-indented files.
The main problem was the `cm-tab` class being an `inline-block` instead of a regular `inline`.
The second problem was the formula you used to calculate the `padding-left`, which wouldn't take character width into account for tab characters.
The style change might break something in CodeMirror. However, I noticed no difference.
I also shortened the regular expression that finds the position of the first non-space character and replaced single quotes with double quotes to be consistent with the rest of the file.
